### PR TITLE
Fix pod failed to validate due to missing attribute homepage

### DIFF
--- a/ios/RNMapboxDirection.podspec
+++ b/ios/RNMapboxDirection.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNMapboxDirection
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/LuncSAS/react-native-mapbox-direction"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
@@ -20,5 +20,3 @@ Pod::Spec.new do |s|
   #s.dependency "others"
 
 end
-
-  


### PR DESCRIPTION
On running `cd ./ios && pod install` causing error;

```
[!] The `RNMapboxDirection` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

This PR is to fix `ERROR | attributes: Missing required attribute homepage`

My react native version is **0.61.5**

Thank you